### PR TITLE
fix: add build_system for correct poetry install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,7 @@ coveralls = "^2.1.2"
 
 [tool.black]
 skip-string-normalization = true
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
### Issue
<!--- Provide a link to the respective issue -->


### Description
<!--- Describe your changes in detail -->
I added `build_system` so that poetry installs logicipi properly instead of naming it `UNKNOWN`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I had to recreate a virtualenvironment that uses this repo, and logicipi was not re-installing properly. Because of changes in pip and setuptools, it was installing as `UNKNOWN`. This change installs it properly.

### Testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Add screenshots if appropriate -->
In my other repo, I installed and uninstalled logicipi using `poetry install` and pip several times, and it would always try to reinstall it, but would name it `UNKNOWN`.
I changed the branch name on `pyproject.toml` to this branch and it installed properly.

### Checklist
<!--- Strikethrough or delete if not necessary -->

