### PR TITLE
fix: add setuptools to remove error from dependent repo CIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,5 +27,5 @@ coveralls = "^2.1.2"
 skip-string-normalization = true
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0", "setuptools"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
### Issue

<!--- Provide a link to the respective issue -->


### Description
<!--- Describe your changes in detail -->
I added setuptools to the requires in the build system.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows dependent repos to build docker containers without having a setuptools error


### Testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Add screenshots if appropriate -->
I opened a PR with a dependent repo to this branch and it was able to build a docker image.


### Checklist
<!--- Strikethrough or delete if not necessary -->
- [ ] Documentation (README, docstrings) has been updated
- [ ] Changes in the code are reflected in the CI configuration
